### PR TITLE
Take dot product for threshold calculation

### DIFF
--- a/timeflux_rasr/estimation.py
+++ b/timeflux_rasr/estimation.py
@@ -176,7 +176,7 @@ class RASR(BaseEstimator, TransformerMixin):
             indx = np.argsort(evals)  # sort in ascending
             evecs = evecs[:, indx]
 
-            keep = (evals[indx] < sum(self.threshold_.dot(evecs) ** 2)) | \
+            keep = (evals[indx] < np.sum(self.threshold_.dot(evecs) ** 2, axis = 0)) | \
                    (np.arange(Ne) < (Ne * (1 - self.max_dimension)))
 
             keep = np.expand_dims(keep, 0)  # for element wise multiplication that follows

--- a/timeflux_rasr/estimation.py
+++ b/timeflux_rasr/estimation.py
@@ -176,7 +176,7 @@ class RASR(BaseEstimator, TransformerMixin):
             indx = np.argsort(evals)  # sort in ascending
             evecs = evecs[:, indx]
 
-            keep = (evals[indx] < sum((self.threshold_ * evecs) ** 2)) | \
+            keep = (evals[indx] < sum(self.threshold_.dot(evecs) ** 2)) | \
                    (np.arange(Ne) < (Ne * (1 - self.max_dimension)))
 
             keep = np.expand_dims(keep, 0)  # for element wise multiplication that follows


### PR DESCRIPTION
The threshold is given by: 

∑i (TiVj)^2

Thus we should take the dot product and sum over the i axis, instead of element wise multiplication. This is also what is done in the Matlab implementation I believe.